### PR TITLE
Add support for tox (http://tox.testrun.org/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ install/warnsimverest.txt
 install/build
 install/dist
 src/simverest.ini
+.tox
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,35 @@
+import sys
+
+extra = {}
+if sys.version_info >= (3, 0):
+    extra.update(use_2to3=True)
+
+from setuptools import setup, find_packages, Command
+
+setup(name='simverest',
+      version='0.0.0',
+      description='A simple dashboard for the Varnish Cache',
+      long_description=open('README.rst').read(),
+      data_files=[('', ['README.rst'])],
+      classifiers=[
+            'License :: OSI Approved :: BSD License',
+            'Intended Audience :: Developers',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 2',
+            'Programming Language :: Python :: 2.4',
+            'Programming Language :: Python :: 2.5',
+            'Programming Language :: Python :: 2.6',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.1',
+          ],
+      keywords='varnish',
+      author='Richard Nienaber',
+      url='https://github.com/rjnienaber/simverest',
+      license='GPL',
+      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+      zip_safe=False,
+      platforms=["any"],
+      tests_require=['mock', 'argparse'],
+      **extra
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27
+
+[testenv]
+commands =
+    pip install -r requirements.txt --use-mirrors --quiet
+    python src/tests/runner.py
+deps =
+    mock


### PR DESCRIPTION
Note that tox is currently failing with the same errors that Travis CI builds are (looks like timezone problems):

```
~/dev/git-repos/simverest$ tox -e py27
GLOB sdist-make: /Users/marca/dev/git-repos/simverest/setup.py
py27 sdist-reinst: /Users/marca/dev/git-repos/simverest/.tox/dist/simverest-0.0.0.zip
py27 runtests: commands[0]
py27 runtests: commands[1]
...................F..........FF.........F
======================================================================
FAIL: test_should_return_all_backends (tests.tests_data.test_serverstate.ServerStateTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/simverest/.tox/py27/lib/python2.7/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/simverest/src/tests/tests_data/test_serverstate.py", line 164, in test_should_return_all_backends
    self.assertEquals(expected, backends)
AssertionError: {'backends': [{'status_code': '200', 'state': 'healthy', 'status_text': 'OK', 'n [truncated]... != {'backends': [{'status_code': '200', 'state': 'healthy', 'status_text': 'OK', 'n [truncated]...
Diff is 700 characters long. Set self.maxDiff to None to see it.

======================================================================
FAIL: test_should_update_backend_state (tests.tests_data.test_serverstate.ServerStateTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/simverest/.tox/py27/lib/python2.7/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/simverest/src/tests/tests_data/test_serverstate.py", line 36, in test_should_update_backend_state
    backend_state)
AssertionError: {'status_code': '200', 'state': 'healthy', 'status_text': 'OK', 'name': 'web2',  [truncated]... != {'status_code': '200', 'state': 'healthy', 'status_text': 'OK', 'name': 'web2',  [truncated]...
  {'name': 'web2',
   'state': 'healthy',
   'status_code': '200',
   'status_text': 'OK',
-  'timestamp': '2011-09-30T23:00:00Z'}
?                      - -  ^^

+  'timestamp': '2011-10-01T07:00:00Z'}
?                     +   + ^^


======================================================================
FAIL: test_should_update_existing_backend_state (tests.tests_data.test_serverstate.ServerStateTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/simverest/.tox/py27/lib/python2.7/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/simverest/src/tests/tests_data/test_serverstate.py", line 54, in test_should_update_existing_backend_state
    backend_state)
AssertionError: {'status_code': '500', 'state': 'sick', 'status_text': 'Internal Server Error',  [truncated]... != {'status_code': '500', 'state': 'sick', 'status_text': 'Internal Server Error',  [truncated]...
  {'name': 'web2',
   'state': 'sick',
   'status_code': '500',
   'status_text': 'Internal Server Error',
-  'timestamp': '2011-09-30T23:00:00Z'}
?                      - -  ^^

+  'timestamp': '2011-10-01T07:00:00Z'}
?                     +   + ^^


======================================================================
FAIL: test_should_return_response_with_no_headers_set (tests.tests_web.test_middleware.NoCacheMiddlewareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/simverest/.tox/py27/lib/python2.7/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/simverest/src/tests/tests_web/test_middleware.py", line 110, in test_should_return_response_with_no_headers_set
    self.assertEquals(headers, response_headers)
AssertionError: Lists differ: [('Content-Length', '2'), ('Ca... != [('Content-Length', '2'), ('Ca...

First differing element 2:
('Expires', 'Fri, 30 Sep 2011 23:00:00 UTC')
('Expires', 'Sat, 01 Oct 2011 07:00:00 UTC')

  [('Content-Length', '2'),
   ('Cache-Control', 'max-age=0,no-cache,no-store,post-check=0,pre-check=0'),
-  ('Expires', 'Fri, 30 Sep 2011 23:00:00 UTC')]
?               ^^^  - ^^^^      ^^

+  ('Expires', 'Sat, 01 Oct 2011 07:00:00 UTC')]
?               ^^^   ^^^^^      ^^


----------------------------------------------------------------------
Ran 42 tests in 0.045s

FAILED (failures=4)
ERROR: InvocationError: '/Users/marca/dev/git-repos/simverest/.tox/py27/bin/python src/tests/runner.py'
_________________________________________________________________________ summary __________________________________________________________________________
ERROR:   py27: commands failed
```
